### PR TITLE
change order of retract/unretract and pause & resume

### DIFF
--- a/klipper_macro/timelapse.cfg
+++ b/klipper_macro/timelapse.cfg
@@ -5,7 +5,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license
 #
-# Macro version 1.0
+# Macro version 1.1
 #
 
 ##### DO NOT CHANGE ANY MACRO!!! #####
@@ -171,6 +171,8 @@ gcode:
 ## speed.extrude: used speed for extrude [mm/min]
 ##
 ## verbose: Enable mesage output of TIMELAPSE_TAKE_FRAME
+## absolute.coordinates: internal use.
+## absolute.extrude: internal use.
 ###############################################################
 [gcode_macro TIMELAPSE_TAKE_FRAME]
 description: Take Timelapse shoot
@@ -185,6 +187,7 @@ variable_speed: {'travel': 100,
                  'retract': 15,
                  'extrude': 15}
 variable_verbose: True
+variable_absolute: {'coordinates': True, 'extrude': True}
 gcode:
   ##### define park position #####
   {% set min = printer.toolhead.axis_minimum %}
@@ -204,15 +207,18 @@ gcode:
   {% endif %}
   ##### end of definition #####
   {% if enable|lower == 'true' %}
+    {% set absolute = {'coordinates': printer.gcode_move.absolute_coordinates,
+                       'extrude'    : printer.gcode_move.absolute_extrude} %}
+    SET_GCODE_VARIABLE MACRO=TIMELAPSE_TAKE_FRAME VARIABLE=absolute VALUE="{absolute}"
     {% if park.enable|lower == 'true' %}
-      PAUSE_BASE
-      G90     ; insure absolute move
       M83     ; insure relative extrution
       {% if printer.extruder.can_extrude|lower == 'false' %}
         {action_respond_info("Timelapse: Warning, minimum extruder temperature not reached!")}
       {% else %}
         G0 E-{extruder.retract} F{speed.retract|int * 60}
       {% endif %}
+      PAUSE_BASE
+      G90     ; insure absolute move
       {% if "xyz" not in printer.toolhead.homed_axes %}
         {action_respond_info("Timelapse: Warning, axis not homed yet!")}
       {% else %}
@@ -256,21 +262,23 @@ gcode:
   {% if timelapse.takingframe %}
     UPDATE_DELAYED_GCODE ID=_WAIT_TIMELAPSE_TAKE_FRAME DURATION=0.5
   {% else %}
+    RESUME_BASE VELOCITY={timelapse.speed.travel}
     {% if printer.extruder.can_extrude|lower == 'false' %}
         {action_respond_info("Timelapse: Warning minimum extruder temperature not reached!")}
     {% else %}
       G0 E{timelapse.extruder.extrude} F{timelapse.speed.extrude|int * 60}
     {% endif %}
-    RESUME_BASE  VELOCITY={timelapse.speed.travel}
+    {% if timelapse.absolute.coordinates|lower == 'false' %} G91 {% endif %}
+    {% if timelapse.absolute.extrude|lower == 'true' %} M82 {% endif %}
   {% endif %}
 
-###################################################################################################
-#                                                                                                 #
-# HYPERLAPSE: Starts or stops a Hyperlapse video                                                  #
+####################################################################################################
+#                                                                                                  #
+# HYPERLAPSE: Starts or stops a Hyperlapse video                                                   #
 # Usage: HYPERLAPSE ACTION=START [CYCLE=time] starts a hyperlapse with cycle time (default 30 sec) #
 #        HYPERLAPSE ACTION=STOP stops the hyperlapse recording                                     # 
-#                                                                                                 #
-###################################################################################################
+#                                                                                                  #
+####################################################################################################
 
 ######################### definition #########################
 ## cycle: cycle time in seconds


### PR DESCRIPTION
Change the order of retract/pause and unretract/resume to minimize oozing. Insure that the motion systems are set back after the frame is taken.

 Signed-off-by: Alex Zellner alexander.zellner@googlemail.com