### PR TITLE
use rename_existing defined in PAUSE and RESUME

### DIFF
--- a/klipper_macro/timelapse.cfg
+++ b/klipper_macro/timelapse.cfg
@@ -215,13 +215,13 @@ gcode:
                          'extrude'    : printer.gcode_move.absolute_extrude} %}
       SET_GCODE_VARIABLE MACRO=TIMELAPSE_TAKE_FRAME VARIABLE=absolute VALUE="{absolute}"
       {% if park.enable|lower == 'true' %}
-        M83     ; insure relative extrution
+        M83     ; insure relative extrusion
         {% if printer.extruder.can_extrude|lower == 'false' %}
           {action_respond_info("Timelapse: Warning, minimum extruder temperature not reached!")}
         {% else %}
           G0 E-{extruder.retract} F{speed.retract|int * 60}
         {% endif %}
-        PAUSE_BASE
+        {printer.configfile.settings['gcode_macro pause'].rename_existing} ; execute the klipper PAUSE command
         G90     ; insure absolute move
         {% if "xyz" not in printer.toolhead.homed_axes %}
           {action_respond_info("Timelapse: Warning, axis not homed yet!")}
@@ -253,7 +253,7 @@ gcode:
   {% if timelapse.takingframe %}
     UPDATE_DELAYED_GCODE ID=_WAIT_TIMELAPSE_TAKE_FRAME DURATION=0.5
   {% else %}
-    RESUME_BASE VELOCITY={timelapse.speed.travel}
+    {printer.configfile.settings['gcode_macro resume'].rename_existing} VELOCITY={timelapse.speed.travel}  ; execute the klipper RESUME command
     {% if printer.extruder.can_extrude|lower == 'false' %}
         {action_respond_info("Timelapse: Warning minimum extruder temperature not reached!")}
     {% else %}


### PR DESCRIPTION
Use the macro name defined by printer.configfile.settings['gcode_macro ...'].rename_existing for the PAUSE and RESUME function of the timelapse park function. This change insures that the macros works regardless which name the user has defined for the PAUSE and RESUME renaming.

Signed-off-by: Alex Zellner alexander.zellner@googlemail.com