### PR TITLE
Macro: Replace PAUSE and RESUME in TIMELAPSE_RENDER

### DIFF
--- a/klipper_macro/timelapse.cfg
+++ b/klipper_macro/timelapse.cfg
@@ -5,7 +5,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license
 #
-# Macro version 1.4
+# Macro version 1.5
 #
 
 ##### DO NOT CHANGE ANY MACRO!!! #####
@@ -321,7 +321,7 @@ gcode:
   {action_respond_info("Timelapse: Rendering started")}
   {action_call_remote_method("timelapse_render", byrendermacro="True")}
   SET_GCODE_VARIABLE MACRO=TIMELAPSE_RENDER VARIABLE=render VALUE=True
-  PAUSE_BASE
+  {printer.configfile.settings['gcode_macro pause'].rename_existing} ; execute the klipper PAUSE command
   UPDATE_DELAYED_GCODE ID=_WAIT_TIMELAPSE_RENDER DURATION=0.5
 
 [delayed_gcode _WAIT_TIMELAPSE_RENDER]
@@ -334,6 +334,6 @@ gcode:
   {% else %}
     {action_respond_info("Timelapse: Rendering finished")}
     M117
-    RESUME_BASE
+    {printer.configfile.settings['gcode_macro resume'].rename_existing} ; execute the klipper RESUME command
   {% endif %}
 


### PR DESCRIPTION
Use the same fix for PAUSE and resume in TIMELAPSE_RENDER as done in TIMELAPSE_TAKE_FRAME

Signed-off-by: Alex Zellner alexander.zellner@googlemail.com