### PR TITLE
Dual extruder support

### DIFF
--- a/klipper_macro/timelapse.cfg
+++ b/klipper_macro/timelapse.cfg
@@ -5,7 +5,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license
 #
-# Macro version 1.10
+# Macro version 1.11
 #
 
 ##### DO NOT CHANGE ANY MACRO!!! #####
@@ -259,7 +259,8 @@ gcode:
         {% endif %}
         SET_GCODE_VARIABLE MACRO=TIMELAPSE_TAKE_FRAME VARIABLE=is_paused VALUE=True
         {printer.configfile.settings['gcode_macro pause'].rename_existing} ; execute the klipper PAUSE command
-        G90     ; insure absolute move
+        SET_GCODE_OFFSET X=0 Y=0 ; this will insure that the head parks always at the same position in a multi setup
+        G90                      ; insure absolute move
         {% if "xyz" not in printer.toolhead.homed_axes %}
           {% if verbose %}{action_respond_info("Timelapse: Warning, axis not homed yet!")}{% endif %}
         {% else %}

--- a/klipper_macro/timelapse.cfg
+++ b/klipper_macro/timelapse.cfg
@@ -247,7 +247,7 @@ gcode:
                           'factor'  : {'speed'  : printer.gcode_move.speed_factor,
                                        'extrude': printer.gcode_move.extrude_factor}} %}
         SET_GCODE_VARIABLE MACRO=TIMELAPSE_TAKE_FRAME VARIABLE=restore VALUE="{restore}"
-        {% if not printer.extruder.can_extrude %}
+        {% if not printer[printer.toolhead.extruder].can_extrude %}
           {% if verbose %}{action_respond_info("Timelapse: Warning, minimum extruder temperature not reached!")}{% endif %}
         {% else %}
           {% if extruder.fw_retract %}
@@ -291,7 +291,7 @@ gcode:
   {% else %}
     {printer.configfile.settings['gcode_macro resume'].rename_existing} VELOCITY={tl.speed.travel}  ; execute the klipper RESUME command
     SET_GCODE_VARIABLE MACRO=TIMELAPSE_TAKE_FRAME VARIABLE=is_paused VALUE=False
-    {% if not printer.extruder.can_extrude %}
+    {% if not printer[printer.toolhead.extruder].can_extrude %}
         {action_respond_info("Timelapse: Warning minimum extruder temperature not reached!")}
     {% else %}
       {% if tl.extruder.fw_retract %}


### PR DESCRIPTION
I'm on a dual extruder Klipper setup and this didn't work well with Moonraker-timelapse.
There's a check in the GCode macro's for the extruder temperature, but it assumes the first extruder. This can be easily fixed though as seen in 114de38.
Running a dual extruder setup almost always involves setting an offset using `SET_GCODE_OFFSET` which defaults to all zero's and can be accessed on `printer.gcode_move.homing_origin` (see https://moonraker.readthedocs.io/en/latest/printer_objects/#gcode_move). I added this offset to the park coordinates because otherwise the toolhead would either be parked incorrectly or outside the bounds causing an error when running the `TIMELAPSE_TAKE_FRAME` macro.
Please let me know if this is all right or it needs improving in any way.