### PR TITLE
Update printer_data config dir for newer versions

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,7 @@ SRCDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/ && pwd )"
 # Default Parameters
 MOONRAKER_TARGET_DIR="${HOME}/moonraker/moonraker/components"
 SYSTEMDDIR="/etc/systemd/system"
-KLIPPER_CONFIG_DIR="${HOME}/klipper_config"
+KLIPPER_CONFIG_DIR="${HOME}/printer_data/config"
 FFMPEG_BIN="/usr/bin/ffmpeg"
 
 # Define text colors


### PR DESCRIPTION
Update the config dir to support newer versions of moonraker/klipper so users don't have to manually change it when they start with a new version like they would in MainsailOS

Bavo Knol <bavo.famknok@gmail.com>