### PR TITLE
feat: Add 2 new park positions

### DIFF
--- a/klipper_macro/timelapse.cfg
+++ b/klipper_macro/timelapse.cfg
@@ -5,7 +5,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license
 #
-# Macro version 1.13
+# Macro version 1.14
 #
 
 ##### DO NOT CHANGE ANY MACRO!!! #####
@@ -105,17 +105,19 @@ gcode:
     {% endif %}
   {% endif %}
   {% if params.PARK_POS %}
-    {% if params.PARK_POS|lower is in ['center','front_left','front_right','back_left','back_right','custom'] %}
-      {% set dic = {'center'     : {'x': park.center.x   , 'y': park.center.y   , 'dz': 1                },
-                    'front_left' : {'x': park.min.x      , 'y': park.min.y      , 'dz': 0                },
-                    'front_right': {'x': park.max.x      , 'y': park.min.y      , 'dz': 0                },
-                    'back_left'  : {'x': park.min.x      , 'y': park.max.y      , 'dz': 0                },
-                    'back_right' : {'x': park.max.x      , 'y': park.max.y      , 'dz': 0                },
-                    'custom'     : {'x': tl.park.custom.x, 'y': tl.park.custom.y, 'dz': tl.park.custom.dz}} %}
+    {% if params.PARK_POS|lower is in ['center','front_left','front_right','back_left','back_right','custom','x_only','y_only'] %}
+      {% set dic = {'center'      : {'x': park.center.x   , 'y': park.center.y   , 'dz': 1                },
+                    'front_left'  : {'x': park.min.x      , 'y': park.min.y      , 'dz': 0                },
+                    'front_right' : {'x': park.max.x      , 'y': park.min.y      , 'dz': 0                },
+                    'back_left'   : {'x': park.min.x      , 'y': park.max.y      , 'dz': 0                },
+                    'back_right'  : {'x': park.max.x      , 'y': park.max.y      , 'dz': 0                },
+                    'custom'      : {'x': tl.park.custom.x, 'y': tl.park.custom.y, 'dz': tl.park.custom.dz},
+                    'x_only'      : {'x': tl.park.custom.x, 'y': 'none'          , 'dz': tl.park.custom.dz},
+                    'y_only'      : {'x': 'none'          , 'y': tl.park.custom.y, 'dz': tl.park.custom.dz}} %}
       {% set _dummy = tl.park.update({'pos':params.PARK_POS|lower}) %}
       {% set _dummy = tl.park.update({'coord':dic[tl.park.pos]}) %}
     {% else %}
-      {action_raise_error("PARK_POS=%s not supported. Allowed values are [CENTER, FRONT_LEFT, FRONT_RIGHT, BACK_LEFT, BACK_RIGHT, CUSTOM]"
+      {action_raise_error("PARK_POS=%s not supported. Allowed values are [CENTER, FRONT_LEFT, FRONT_RIGHT, BACK_LEFT, BACK_RIGHT, CUSTOM, X_ONLY, Y_ONLY]"
                           % params.PARK_POS|upper)}
     {% endif %}
   {% endif %}
@@ -197,7 +199,7 @@ gcode:
 ## takingframe: internal use. Valid inputs: [True, False]
 ##
 ## park.enable: enable or disable to park the head while taking a picture. Valid inputs: [True, False]
-## park.pos   : used position for parking. Valid inputs: [center, front_left, front_right, back_left, back_right, custom]
+## park.pos   : used position for parking. Valid inputs: [center, front_left, front_right, back_left, back_right, custom, x_only, y_only]
 ## park.time  : used for the debug macro. Time in s
 ## park.custom.x, park.custom.y: coordinates of the custom parkposition. Unit [mm]
 ## park.custom.dz              : custom z hop for the picture. Unit [mm]
@@ -250,8 +252,9 @@ gcode:
     {% if (hyperlapse and printer['gcode_macro HYPERLAPSE'].run) or
           (not hyperlapse and not printer['gcode_macro HYPERLAPSE'].run) %}
       {% if park.enable %}
-        {% set pos = {'x': park.coord.x, 'y': park.coord.y, 
-                      'z': [printer.gcode_move.gcode_position.z + park.coord.dz, printer.toolhead.axis_maximum.z]|min} %}
+        {% set pos = {'x': 'X' + park.coord.x|string if park.pos != 'y_only' else '', 
+                      'y': 'Y' + park.coord.y|string if park.pos != 'x_only' else '', 
+                      'z': 'Z'+ [printer.gcode_move.gcode_position.z + park.coord.dz, printer.toolhead.axis_maximum.z]|min|string} %}
         {% set restore = {'absolute': {'coordinates': printer.gcode_move.absolute_coordinates,
                                        'extrude'    : printer.gcode_move.absolute_extrude},
                           'speed'   : printer.gcode_move.speed,
@@ -276,7 +279,7 @@ gcode:
         {% if "xyz" not in printer.toolhead.homed_axes %}
           {% if verbose %}{action_respond_info("Timelapse: Warning, axis not homed yet!")}{% endif %}
         {% else %}
-          G0 X{pos.x} Y{pos.y} Z{pos.z} F{speed.travel * 60}
+          G0 {pos.x} {pos.y} {pos.z} F{speed.travel * 60}
         {% endif %}
         SET_GCODE_VARIABLE MACRO=TIMELAPSE_TAKE_FRAME VARIABLE=takingframe VALUE=True
         UPDATE_DELAYED_GCODE ID=_WAIT_TIMELAPSE_TAKE_FRAME DURATION=0.5


### PR DESCRIPTION
Following https://github.com/mainsail-crew/moonraker-timelapse/issues/74

2 new park modes are added
- X_ONLY: uses CUSTOM_POS_X and CUSTOM_POS_DZ to move only in these 2 directions
- Y_ONLY: uses CUSTOM_POS_Y and CUSTOM_POS_DZ to move only in these 2 directions

Signed-off-by: Alex Zellner <alexander.zellner@googlemail.com>