### PR TITLE
docs: Update configuration documentation

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,10 +1,9 @@
-This document describes Moonraker-timelapse configuration.  As this file
-references configuration for both Klipper (`printer.cfg`) and Moonraker
-(`moonraker.conf`), each example contains a commment indicating which
-configuration file is being refrenenced. 
+This document describes configuration for the moonraker-timelapse component. As this file references configuration for both Klipper (`printer.cfg`) and Moonraker (`moonraker.conf`), each example contains a commment indicating which configuration file is being referenced.
 
-### Define the Gcode Macro
-Include the macro file to your printer.cfg
+### Include the Macro
+
+Include the macro file in your printer.cfg
+
 ```ini
 # printer.cfg
 
@@ -13,37 +12,37 @@ Include the macro file to your printer.cfg
 ```
 
 ## Slicer Setup
-To use the "layermacro" mode which grabs a frame every layerchange you need to
-add the ``TIMELAPSE_TAKE_FRAME`` macro to your slicer so that it is added to
-the Gcode before or after a layer change. If your slicer does not support adding
-Gcode to a layerchange you are limited to the timebased "hyperlapse" mode.
 
-### Prusa Slicer / Super Slicer
-Printer Settings -> Custom G-code -> Before layer change Gcode -> ``TIMELAPSE_TAKE_FRAME``
+To use the `layermacro` mode which grabs a frame every layer change, you will need to add the `TIMELAPSE_TAKE_FRAME` macro to your slicer so that it is added to the G-code before or after a layer change. If your slicer does not support adding G-code to a layer change, you are limited to the timebased `hyperlapse` mode.
+
+### Prusa Slicer / Super Slicer / Other Slic3r Forks
+
+Printer Settings -> Custom G-code -> Before layer change G-code -> `TIMELAPSE_TAKE_FRAME`
 
 ![PrusaSlicer Configuration](assets/img/timelapse-PS-config.png)
 
 ### Ultimaker Cura
-Extensions -> Post Processing -> Modify G-Code ->   
-Add a script -> Insert at layer change -> G-code to insert = ``TIMELAPSE_TAKE_FRAME``
+
+Extensions -> Post Processing -> Modify G-Code -> Add a script -> Insert at layer change -> G-code to insert = `TIMELAPSE_TAKE_FRAME`
 
 ![Cura Configuration](assets/img/timelapse-cura-config.png)
 
-
 ### Ideamaker
-Advanced Settings -> Gcode -> Layer Change Gcode -> ``TIMELAPSE_TAKE_FRAME``
+
+Advanced Settings -> Gcode -> Layer Change Gcode -> `TIMELAPSE_TAKE_FRAME`
 
 ![Cura Configuration](assets/img/timelapse-ideamaker-config.png)
 (Credits to Vez3d for the screenshot)
 
 ## Activate the Component
+
 ```ini
 # moonraker.conf
 
 [timelapse]
 ##   Following basic configuration is default to most images and don't need
 ##   to be changed in most scenarios. Only uncomment and change it if your
-##   Image differ from standart installations. In most common scenarios 
+##   Image differ from standart installations. In most common scenarios
 ##   a User only need [timelapse] in there configuration.
 #output_path: ~/timelapse/
 ##   Directory where the generated video will be saved
@@ -56,153 +55,180 @@ Advanced Settings -> Gcode -> Layer Change Gcode -> ``TIMELAPSE_TAKE_FRAME``
 ```
 
 ## Configuration of the Component
-Configuration offered by the '/machine/timelapse/settings' endpoint
+
+Configuration offered by the `/machine/timelapse/settings` endpoint
 
 ### General
 
 #### enabled
-'true' enables or 'false' disables the plugin.
-In a disabled state gcode macros are ignored and autorender is skipped.
+
+`true` enables or `false` disables the plugin.
+In a disabled state, gcode macros are ignored and autorender is skipped.
 This helps if you have macros setup in your slicer but like to manually
 skip timelapse for a print.
 
 #### mode
-At the moment there are two modes available 'layermacro' and 'hyperlapse'
 
-##### layermacro 
-This mode uses a macro to trigger frame grabbing, but needs the slicer to be setup
-to add such on layerchange (refer to the 'Slicer setup' below) 
+At the moment there are two modes available: `layermacro` and `hyperlapse`
+
+##### layermacro
+
+This mode uses a macro to trigger frame grabbing, but needs the slicer to be setup to trigger the macro on layerchange (refer to [Slicer Setup](#slicer-setup))
 
 ##### hyperlapse
+
 This mode takes a frame every x seconds configured by the hyperlapse_cycle setting
 
 #### hyperlapse_cycle
+
 Defines the time interval in which a frame gets taken in the hyperlapse mode.
 
 #### autorender
-'true' enables or 'false' disables automatic trigger of the render process
-at the end of the print. Alternatively you can use the 'TIMELAPSE_RENDER' in
-your end gcode or the Render http Endpoint (which may be integrated into your 
-frontend) to trigger the render process.
+
+`true` enables or `false` disables automatic trigger of the render process
+at the end of the print. Alternatively you can use the 'TIMELAPSE_RENDER' macro in your end gcode or the Render HTTP endpoint (which may be integrated into your frontend) to trigger the render process.
 
 #### saveFrames
-'True' enables or 'False' disables packing the frames to a zip file for external
-use or render.
+
+`true` enables or `false` disables packing the frames to a zip file for external use or render.
 
 ### Takeframe specific
 
 #### camera
-This setting let you choose which camera should be used to take frames from.
+
+This setting lets you choose which camera should be used to take frames.
 It depends on the 'webcam' namespace in the moonraker DB and uses the
-'snapshoturl', 'flipX' and 'flipY' associated whith selected camera. Alternatively you can configure
-'snapshoturl', 'flip_x' and 'flip_y' in the moonraker.conf if your frontend doesn't support the webcams 
-namespace of moonraker DB.
+'snapshoturl', 'flipX' and 'flipY' associated with the selected camera. Alternatively, you can configure `snapshoturl`, `flip_x` and `flip_y` in moonraker.conf if your frontend doesn't support the webcams namespace of the moonraker DB.
 
 #### gcode_verbose
-'true' enables or 'false' disables verbosity of the Macros
+
+`true` enables or `false` disables verbosity of the macros
 
 #### parkhead
-'true' enables or 'false' disables parking the printhead before taking a frame.
+
+`true` enables or `false` disables parking the printhead before taking a frame.
 
 #### parkpos
-This defines the position where to park the printhead before taking a frame.
-Possible configurations are [center, front_left, front_right, back_left, back_right, custom]
 
-##### Custom parkpos
-If you like to define a custom parkposition of your printhead.
+This defines the position where to park the printhead before taking a frame. Possible configurations are `[center, front_left, front_right, back_left, back_right, custom]`
+
+##### custom
+
+If you plan to define a custom parkposition of your printhead.
 
 ##### park_custom_pos_x
-Absolut X coordinates of the custom parkposition (Unit mm)
+
+Absolute X coordinates of the custom parkposition (in mm)
 
 ##### park_custom_pos_y
-Absolut Y coordinates of the custom parkposition (Unit mm)
+
+Absolute Y coordinates of the custom parkposition (in mm)
 
 ##### park_custom_pos_dz
-Relative Y coordinates of the custom parkposition (Unit mm)
-        
+
+Relative Y coordinates of the custom parkposition (in mm)
+
 #### park_travel_speed
-Speed of the printhead movement while parking (Unit mm/s)
+
+Speed of the printhead while parking (in mm/s)
 
 #### park_retract_speed
-Speed of the retract while parking (Unit mm/s)
+
+Speed of the retract while parking (in mm/s)
 
 #### park_extrude_speed
-Speed of the extrude when resuming the print (Unit mm/s)
+
+Speed of the extrude when resuming the print (in mm/s)
 
 #### park_retract_distance
-Distance to retract the filament to prevent oozing (Unit mm)
+
+Distance to retract the filament to prevent oozing (in mm)
 
 #### park_extrude_distance
-Distance to extrude to fill the nozzle before resuming the print (Unit mm)
+
+Distance to extrude to fill the nozzle before resuming the print (in mm)
 
 #### fw_retract
-'true' enables or 'false' disables use of firmware retraction in the macro.
+
+`true` enables or `false` disables use of firmware retraction in the macro.
 Note: Enabling this will disable retract related settings!
 
 #### park_time
-add additional idle time when parking (Unit seconds, default 0.1)
+
+Add additional idle time when parking (in seconds, default 0.1)
 
 #### stream_delay_compensation
-delay frame capture (Unit seconds, default 0.05)
 
-### Render specific
+Delay frame capture (in seconds, default 0.05)
+
+### Render Specific
 
 #### time_format_code
-This defines how the rendered video should be named. 
-It uses the python datetime format. Default is "%Y%m%d_%H%M".
-More info about the datetime format can be found here https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes
+
+This defines how the rendered video should be named. It uses the python datetime format. Default is "%Y%m%d\_%H%M".
+More info about the datetime format can be found in the [Python Documentation](https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes)
 
 #### output_framerate
-Defines the Framerate of the video. (Unit frames per second)
+
+Defines the framerate of the video. (in frames per second)
 Note: this will be ignored if variable_fps is enabled.
 
 #### variable_fps
-'true' enables or 'false' disables variable calcuation of the output framerate.
-This uses the count of taken frames and 'targetlength', but is limited by
-'variable_fps_min' and 'variable_fps_max' settings.
+
+`true` enables or `false` disables variable calcuation of the output framerate.
+This uses the count of taken frames and `targetlength`, but is limited by
+`variable_fps_min` and `variable_fps_max` settings.
 
 #### targetlength
-Defines the target length of a video (Unit seconds)
+
+Defines the target length of a video (in seconds)
 
 #### variable_fps_min
-Minimum fps for variable_fps (Unit frames per second).
+
+Minimum fps for variable_fps (in frames per second).
 
 #### variable_fps_min
-Maximum fps for variable_fps (Unit frames per second).
+
+Maximum fps for variable_fps (in frames per second).
+
+#### flip_x
+
+Flips the rendered timelapse horizontally.
+
+#### flip_y
+
+Flips the rendered timelapse vertically.
+
+#### rotation
+
+Rotates the rendered timelapse X degrees (0-360)
 
 #### constant_rate_factor
-This configure quality vs filesize of the rendered Video. The range of the CRF 
-scale is 0–51, where 0 is lossless, 23 is the default and 51 is worst quality
-possible. A lower value generally leads to higher quality and a subjectively
-sane range is 17–28. Consider 17 or 18 to be visually lossless.
-more info: https://trac.ffmpeg.org/wiki/Encode/H.264
+
+This configures quality vs filesize of the rendered video. The range of the CRF scale is 0–51, where 0 is lossless, 23 is the default and 51 is the worst quality possible. A lower value generally leads to higher quality, and a subjectively sane range is 17–28. Consider 17 or 18 to be visually lossless. [More info](https://trac.ffmpeg.org/wiki/Encode/H.264)
 
 #### pixelformat
-Defines the pixelformat of the output video. Some older h264 devices like
-mobiles and others need 'yuv420p' which is default the timelapse component.
-To get more info which pixelformats are available run 'ffmpeg -pix_fmts' in 
-your system console or refer to the ffmpeg documentation: https://ffmpeg.org/ffmpeg.html
+
+Defines the pixelformat of the output video. Some older h264 devices like mobiles and others need 'yuv420p' which is the default for the timelapse component. To get more info which pixelformats are available run `ffmpeg -pix_fmts` in your system console or refer to the [ffmpeg documentation](https://ffmpeg.org/ffmpeg.html)
 
 #### duplicatelastframe
+
 Duplicates the last frame to the end of the output video.
 
 #### extraoutputparams
-Defines extra output parameters to FFMPEG 
-further info: https://ffmpeg.org/ffmpeg.html 
-Note: Specifing anything here will maybe disable other features! (ffmpeg limitation)
+
+Defines extra output parameters to pass to FFMPEG. [Further info](https://ffmpeg.org/ffmpeg.html)
+Note: Specifying anything here has the potential to disable other features! (ffmpeg limitation)
 
 #### previewImage
-'true' enables or 'false' disables coping the last frame as a preview image to
-the output directory. This is used so that the frontend can show a preview of 
-the timelapse without needing to open the video.
 
-## Fallback Configfile based moonraker.conf
-The Plugin offers configuration via a Http API which is the preferred method to
-configure Timelapse. How ever if your frontend doesn't support those
-configuration there is a Fallback  to moonraker.conf. However beware adding and
-uncommenting this in your moonraker.conf will disable the possibility to change
-the setting in the frontend. Please refer to section above what each setting
-does.
+`true` enables or `false` disables copying the last frame as a preview image to the output directory. This is used so that the frontend can show a preview of the timelapse without needing to open the video.
+
+## Fallback to moonraker.conf
+
+This component offers configuration via an HTTP API which is the preferred method to configure moonraker-timelapse. However, if your frontend doesn't support configuration, moonraker-timelapse will fallback to moonraker.conf.
+
+Note: adding and uncommenting this in your moonraker.conf will disable the possibility to change these settings in the frontend. Please refer to the sections above to what each setting does.
 
 ```ini
 
@@ -229,13 +255,14 @@ does.
 #output_framerate: 30
 #pixelformat: yuv420p
 #time_format_code: %Y%m%d_%H%M
-#extraoutputparams: 
+#extraoutputparams:
 #variable_fps: False
 #targetlength: 10
 #variable_fps_min: 5
 #variable_fps_max: 60
 #flip_x: False
 #flip_y: False
+#rotation: 0
 #duplicatelastframe: 0
 #previewimage: True
 #saveframes: False
@@ -244,9 +271,9 @@ does.
 ```
 
 ## Change the Resolution of your Camera
-You may want to change your Timelapse to a higher resolution, you
-need to change the Webcamstream to a higher resolution since the
-Component will grab the frame of the Streamer.
-To do so, please refer to the documentation of your Image:  
-- MainsailOS: https://docs.mainsail.xyz/quicktips/multicam
-- FluiddPI: https://docs.fluidd.xyz/features/cameras 
+
+You may want to change your timelapse to a higher resolution. To do this, you will need to change the webcam stream to a higher resolution since the component will grab the frame of the from the stream.
+To do so, please refer to the documentation of your Image:
+
+-   MainsailOS: https://docs.mainsail.xyz/quicktips/multicam
+-   FluiddPI: https://docs.fluidd.xyz/features/cameras

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -275,5 +275,5 @@ Note: adding and uncommenting this in your moonraker.conf will disable the possi
 You may want to change your timelapse to a higher resolution. To do this, you will need to change the webcam stream to a higher resolution since the component will grab the frame of the from the stream.
 To do so, please refer to the documentation of your Image:
 
--   MainsailOS: https://docs.mainsail.xyz/quicktips/multicam
+-   MainsailOS: https://crowsnest.mainsail.xyz/
 -   FluiddPI: https://docs.fluidd.xyz/features/cameras


### PR DESCRIPTION
This PR aims to update the configuration docs to fix typos, include missing parameters, and fix sentence structure.

The explanation of some parameters are not included in the current configuration documents, so I've added them. I also fixed some sentences, typos, and other grammatical areas to clean it up and make it a bit easier to follow I was there.

Signed-off-by:  Mike Constantino <mikebconstantino@gmail.com>