### PR TITLE
catch all frames and ignore missing ones

### DIFF
--- a/component/timelapse.py
+++ b/component/timelapse.py
@@ -614,7 +614,7 @@ class Timelapse:
             # prepare output filename
             now = datetime.now()
             date_time = now.strftime(self.config['time_format_code'])
-            inputfiles = self.temp_dir + "frame%6d.jpg"
+            inputfiles = self.temp_dir + "frame*.jpg"
             outfile = f"timelapse_{gcodefilename}_{date_time}"
 
             # dublicate last frame


### PR DESCRIPTION
When timelapse_take_frame macro fails and unable to save frame for it, timelapse video creation stops on the missing frame. This change should catch them all.