### PR TITLE
[issue 119] Parking head cancel pause print, when is timelapse in hyperlapse mode.

### DIFF
--- a/klipper_macro/timelapse.cfg
+++ b/klipper_macro/timelapse.cfg
@@ -249,8 +249,9 @@ variable_is_paused: False
 gcode:
   {% set hyperlapse = True if params.HYPERLAPSE and params.HYPERLAPSE|lower =='true' else False %}
   {% if enable %}
-    {% if (hyperlapse and printer['gcode_macro HYPERLAPSE'].run) or
-          (not hyperlapse and not printer['gcode_macro HYPERLAPSE'].run) %}
+    {% if ((hyperlapse and printer['gcode_macro HYPERLAPSE'].run) or
+          (not hyperlapse and not printer['gcode_macro HYPERLAPSE'].run)) and
+          (printer.print_stats.state == 'printing')%}
       {% if park.enable %}
         {% set pos = {'x': 'X' + park.coord.x|string if park.pos != 'y_only' else '', 
                       'y': 'Y' + park.coord.y|string if park.pos != 'x_only' else '', 


### PR DESCRIPTION
This is my fix for the issue. Running takeing photos only, if the state is printing. I'm not sure if it's enough, but it work for me. 