### PR TITLE
Feature: Add user configurable delayed_gcode interval

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -250,3 +250,21 @@ Component will grab the frame of the Streamer.
 To do so, please refer to the documentation of your Image:  
 - MainsailOS: https://crowsnest.mainsail.xyz/configuration/cam-section#resolution
 - FluiddPI: https://docs.fluidd.xyz/features/cameras 
+
+## Reduce the check interval inside the klipper macros
+The default is that the macros check every 0.5 sec if the print can continue.
+This is a good compromise between cpu load and quality. From now one you can change
+this time.
+Caution, smaller numbers increase the risk of a klipper "timer to close"
+
+To change it simple, add the following GCODE to your print start:
+```ini
+SET_GCODE_VARIABLE MACRO=TIMELAPSE_TAKE_FRAME VARIABLE=check_time VALUE=0.5 
+``` 
+
+To get that change at every klipper start:
+```ini
+[delayed_gcode _INIT_TIMELAPSE_CHECK_TIME]
+initial_duration: 1
+gcode: SET_GCODE_VARIABLE MACRO=TIMELAPSE_TAKE_FRAME VARIABLE=check_time VALUE=0.5 
+``` 

--- a/klipper_macro/timelapse.cfg
+++ b/klipper_macro/timelapse.cfg
@@ -5,7 +5,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license
 #
-# Macro version 1.14
+# Macro version 1.15
 #
 
 ##### DO NOT CHANGE ANY MACRO!!! #####
@@ -215,6 +215,8 @@ gcode:
 ##
 ## verbose: Enable mesage output of TIMELAPSE_TAKE_FRAME
 ##
+## check_time: time when the status of the taken picture is checked. Default 0.5 sec
+##
 ## restore.absolute.coordinates: internal use
 ## restore.absolute.extrude    : internal use
 ## restore.speed               : internal use
@@ -243,6 +245,7 @@ variable_speed: {'travel': 100,
                  'retract': 15,
                  'extrude': 15}
 variable_verbose: True
+variable_check_time: 0.5
 variable_restore: {'absolute': {'coordinates': True, 'extrude': True}, 'speed': 1500, 'e':0, 'factor': {'speed': 1.0, 'extrude': 1.0}}
 variable_macro: {'pause': 'PAUSE', 'resume': 'RESUME'}
 variable_is_paused: False
@@ -282,7 +285,7 @@ gcode:
           G0 {pos.x} {pos.y} {pos.z} F{speed.travel * 60}
         {% endif %}
         SET_GCODE_VARIABLE MACRO=TIMELAPSE_TAKE_FRAME VARIABLE=takingframe VALUE=True
-        UPDATE_DELAYED_GCODE ID=_WAIT_TIMELAPSE_TAKE_FRAME DURATION=0.5
+        UPDATE_DELAYED_GCODE ID=_WAIT_TIMELAPSE_TAKE_FRAME DURATION={check_time}
         M400
       {% endif %}
       _TIMELAPSE_NEW_FRAME HYPERLAPSE={hyperlapse}
@@ -303,7 +306,7 @@ gcode:
   {% set tl = printer['gcode_macro TIMELAPSE_TAKE_FRAME'] %}
   {% set factor = {'speed': printer.gcode_move.speed_factor, 'extrude': printer.gcode_move.extrude_factor} %}
   {% if tl.takingframe %}
-    UPDATE_DELAYED_GCODE ID=_WAIT_TIMELAPSE_TAKE_FRAME DURATION=0.5
+    UPDATE_DELAYED_GCODE ID=_WAIT_TIMELAPSE_TAKE_FRAME DURATION={tl.check_time}
   {% else %}
     {tl.macro.resume} VELOCITY={tl.speed.travel} ; execute the klipper RESUME command
     SET_GCODE_VARIABLE MACRO=TIMELAPSE_TAKE_FRAME VARIABLE=is_paused VALUE=False


### PR DESCRIPTION
This adds to possibility that the user change the polling interval insight klipper to react faster to the taken picture.

Signed-off-by: Alex Zellner [alexander.zellner@googlemail.com](mailto:alexander.zellner@googlemail.com)