### PR TITLE
Add configurable wget command timeout

### DIFF
--- a/component/timelapse.py
+++ b/component/timelapse.py
@@ -64,6 +64,8 @@ class Timelapse:
             "ffmpeg_binary_path", "/usr/bin/ffmpeg")
         self.wget_skip_cert = confighelper.getboolean(
             "wget_skip_cert_check", False)
+        self.wget_timeout_seconds = confighelper.getfloat(
+            "wget_timeout_seconds", 2.0)
 
         # Setup default config
         self.config: Dict[str, Any] = {
@@ -478,7 +480,7 @@ class Timelapse:
         shell_cmd: SCMDComp = self.server.lookup_component('shell_command')
         scmd = shell_cmd.build_shell_command(cmd, None)
         try:
-            cmdstatus = await scmd.run(timeout=2., verbose=False)
+            cmdstatus = await scmd.run(timeout=self.wget_timeout_seconds, verbose=False)
         except Exception:
             logging.exception(f"Error running cmd '{cmd}'")
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -240,6 +240,7 @@ does.
 #previewimage: True
 #saveframes: False
 #wget_skip_cert_check: False
+#wget_timeout_seconds: 2
 
 ```
 


### PR DESCRIPTION
This PR adds a new "wget_timeout_seconds" that allows the user to configure the wget command timeout. With the default 2s timeout, I was routinely getting timelapse cancelled errors due to the command timing out. This option might help out the poor folks with slow networks. 