### PR TITLE
taking snapshots via shellcommand by "cmd:"-prefix

### DIFF
--- a/component/timelapse.py
+++ b/component/timelapse.py
@@ -248,7 +248,7 @@ class Timelapse:
                                                            rotation
                                                            )
 
-        if not self.config['snapshoturl'].startswith('http'):
+        if not self.config['snapshoturl'].startswith('http') and not self.config['snapshoturl'].startswith('cmd:'):
             if not self.config['snapshoturl'].startswith('/'):
                 self.config['snapshoturl'] = "http://localhost/" + \
                                              self.config['snapshoturl']
@@ -470,15 +470,22 @@ class Timelapse:
 
         self.framecount += 1
         framefile = "frame" + str(self.framecount).zfill(6) + ".jpg"
-        cmd = "wget " + options + self.config['snapshoturl'] \
-              + " -O " + self.temp_dir + framefile
+        url = self.config['snapshoturl']
+        waittime = 2.
+        if self.config['snapshoturl'].startswith('cmd:'):
+            cmdStart = self.config['snapshoturl'][4:]
+            cmd = cmdStart + " " + self.temp_dir + framefile
+            waittime = 10.
+        else:
+            cmd = "wget " + options + self.config['snapshoturl'] \
+                + " -O " + self.temp_dir + framefile
         self.lastframefile = framefile
         logging.debug(f"cmd: {cmd}")
 
         shell_cmd: SCMDComp = self.server.lookup_component('shell_command')
         scmd = shell_cmd.build_shell_command(cmd, None)
         try:
-            cmdstatus = await scmd.run(timeout=2., verbose=False)
+            cmdstatus = await scmd.run(timeout=waittime, verbose=False)
         except Exception:
             logging.exception(f"Error running cmd '{cmd}'")
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -95,8 +95,11 @@ use or render.
 This setting let you choose which camera should be used to take frames from.
 It depends on the 'webcam' namespace in the moonraker DB and uses the
 'snapshoturl', 'flipX' and 'flipY' associated whith selected camera. Alternatively you can configure
-'snapshoturl', 'flip_x' and 'flip_y' in the moonraker.conf if your frontend doesn't support the webcams 
+'snapshoturl', 'flip_x' and 'flip_y' in the moonraker.conf if your frontend doesn't support the webcams
 namespace of moonraker DB.
+
+'snapshoturl' can be a shellcommand, when the value is prefixed with 'cmd:', eg. 'cmd:/home/pi/bin/canondslrtakeframe.sh'.
+The first argument is the absolute frame-filenmae.
 
 #### gcode_verbose
 'true' enables or 'false' disables verbosity of the Macros


### PR DESCRIPTION
example which uses gphoto2 to download pic from a DSLR
```
... moonraker.conf...

[webcam canon]
location: printer
icon:
enabled: False
stream_url: /webcam/stream
snapshot_url: cmd:/home/pi/bin/canoncaptureframe
```

_canoncaptureframe_
```shell
BASEFILE=${1%%.jpg}
gphoto2 --quiet --capture-image-and-download --filename="$BASEFILE.%C" --force-overwrite
rm -f "$BASEFILE.cr3"
```