### PR TITLE
feature custom snapshot_cmd implemented

### DIFF
--- a/component/timelapse.py
+++ b/component/timelapse.py
@@ -248,7 +248,7 @@ class Timelapse:
                                                            rotation
                                                            )
 
-        if not self.config['snapshoturl'].startswith('http'):
+        if not self.config['snapshoturl'].startswith('http') and not self.config['snapshoturl'].startswith('cmd:'):
             if not self.config['snapshoturl'].startswith('/'):
                 self.config['snapshoturl'] = "http://localhost/" + \
                                              self.config['snapshoturl']
@@ -470,15 +470,22 @@ class Timelapse:
 
         self.framecount += 1
         framefile = "frame" + str(self.framecount).zfill(6) + ".jpg"
-        cmd = "wget " + options + self.config['snapshoturl'] \
-              + " -O " + self.temp_dir + framefile
+        url = self.config['snapshoturl']
+        waittime = 2.
+        if self.config['snapshoturl'].startswith('cmd:'):
+            cmdStart = self.config['snapshoturl'][4:]
+            cmd = cmdStart + " " + self.temp_dir + framefile
+            waittime = 10.
+        else:
+            cmd = "wget " + options + self.config['snapshoturl'] \
+                + " -O " + self.temp_dir + framefile
         self.lastframefile = framefile
         logging.debug(f"cmd: {cmd}")
 
         shell_cmd: SCMDComp = self.server.lookup_component('shell_command')
         scmd = shell_cmd.build_shell_command(cmd, None)
         try:
-            cmdstatus = await scmd.run(timeout=2., verbose=False)
+            cmdstatus = await scmd.run(timeout=waittime, verbose=False)
         except Exception:
             logging.exception(f"Error running cmd '{cmd}'")
 

--- a/component/timelapse.py
+++ b/component/timelapse.py
@@ -497,17 +497,17 @@ class Timelapse:
 
         self.framecount += 1
         framefile = "frame" + str(self.framecount).zfill(6) + ".jpg"
-        url = self.config['snapshoturl']
-        waittime = 2.
         if self.config['use_snapshot_cmd'] == True and not self.snapshotCmdWorking:
             logging.info(f"snapshot_cmd_check failed on startup or snapshot_cmd is empty: {self.config['snapshot_cmd']}")
 
+        waittime = 2.
         if self.config['use_snapshot_cmd'] == True and self.snapshotCmdWorking:
             cmd = self.config['snapshot_cmd'] + " " + self.temp_dir + framefile
             waittime = self.config['snapshot_cmd_waittime']
         else:
             cmd = "wget " + options + self.config['snapshoturl'] \
                 + " -O " + self.temp_dir + framefile
+
         self.lastframefile = framefile
         logging.debug(f"cmd: {cmd}")
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -95,8 +95,11 @@ use or render.
 This setting let you choose which camera should be used to take frames from.
 It depends on the 'webcam' namespace in the moonraker DB and uses the
 'snapshoturl', 'flipX' and 'flipY' associated whith selected camera. Alternatively you can configure
-'snapshoturl', 'flip_x' and 'flip_y' in the moonraker.conf if your frontend doesn't support the webcams 
+'snapshoturl', 'flip_x' and 'flip_y' in the moonraker.conf if your frontend doesn't support the webcams
 namespace of moonraker DB.
+
+'snapshoturl' can be a shellcommand, when the value is prefixed with 'cmd:', eg. 'cmd:/home/pi/bin/canondslrtakeframe.sh'.
+The first argument is the absolute frame-filenmae.
 
 #### gcode_verbose
 'true' enables or 'false' disables verbosity of the Macros

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -98,8 +98,20 @@ It depends on the 'webcam' namespace in the moonraker DB and uses the
 'snapshoturl', 'flip_x' and 'flip_y' in the moonraker.conf if your frontend doesn't support the webcams
 namespace of moonraker DB.
 
-'snapshoturl' can be a shellcommand, when the value is prefixed with 'cmd:', eg. 'cmd:/home/pi/bin/canondslrtakeframe.sh'.
-The first argument is the absolute frame-filenmae.
+#### use_snapshot_cmd
+'true' enables snapshot_cmd processing.
+
+#### snapshot_cmd
+This defines which creates the snapshot. The
+See scripts/gphoto2_capture.sh for an example
+
+#### snapshot_cmd_check'
+This defines an optional testscript, which is run on start of the job. It checks if the camera is available.
+If not, the normal webcam is used.
+
+#### snapshot_cmd_waittime
+This defines the wait time for the snapshot to be created.
+You should increase the 'park_time' setting for better results.
 
 #### gcode_verbose
 'true' enables or 'false' disables verbosity of the Macros

--- a/scripts/gphoto2_capture.sh
+++ b/scripts/gphoto2_capture.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+BASEFILE=${1%%.jpg}
+
+# note: make sure that you're camera just creates small/medium jpg and no raws or
+# you're raspberrypi will habe all lot of data to process
+
+gphoto2 --quiet --capture-image-and-download --filename="$BASEFILE.%C" --force-overwrite

--- a/scripts/gphoto2_check.sh
+++ b/scripts/gphoto2_check.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+#fails if camera is not connected
+exec gphoto2 --get-config /main/imgsettings/imageformat >& /dev/null


### PR DESCRIPTION
This PR introduces 4 new timelapse-options .
It allows making timelapses via invocation of a custom shellscript.
In my case i'm using gphoto2 to control a Canon EOS70D  camara.
It `use_snapshot_cmd` is `False` or `snapshot_cmd_check` fails, the normal configuration is used.

```
[timelapse]
    use_snapshot_cmd: True
    snapshot_cmd: /home/pi/bin/gphoto2_capture.sh
    snapshot_cmd_check: /home/pi/bin/gphoto2_check.sh
    snapshot_cmd_waittime: 10.0
```