### PR TITLE
Added quotes to wget params

### DIFF
--- a/component/timelapse.py
+++ b/component/timelapse.py
@@ -470,8 +470,9 @@ class Timelapse:
 
         self.framecount += 1
         framefile = "frame" + str(self.framecount).zfill(6) + ".jpg"
-        cmd = "wget " + options + self.config['snapshoturl'] \
-              + " -O " + self.temp_dir + framefile
+        cmd = ("wget " + options \
+              + " '" + self.config['snapshoturl'] + "'" \
+              + " -O '" + self.temp_dir + framefile + "'")
         self.lastframefile = framefile
         logging.debug(f"cmd: {cmd}")
 


### PR DESCRIPTION
Added quotes for URL and file name of wget call used for take frame, this will fix wget call with special chars in file name and/or URL. Could help with #173 as well (maybe in combination with PR #150).