### PR TITLE
feat: Avoid wiping the toolhead on the model when resuming

### DIFF
--- a/klipper_macro/timelapse.cfg
+++ b/klipper_macro/timelapse.cfg
@@ -261,6 +261,9 @@ gcode:
         {% set restore = {'absolute': {'coordinates': printer.gcode_move.absolute_coordinates,
                                        'extrude'    : printer.gcode_move.absolute_extrude},
                           'speed'   : printer.gcode_move.speed,
+			  'pos'     : {'x': printer.toolhead.position.x,
+				       'y': printer.toolhead.position.y,
+				       'z': [printer.gcode_move.gcode_position.z + park.coord.dz, printer.toolhead.axis_maximum.z]|min},
                           'e'       : printer.gcode_move.gcode_position.e,
                           'factor'  : {'speed'  : printer.gcode_move.speed_factor,
                                        'extrude': printer.gcode_move.extrude_factor}} %}
@@ -308,6 +311,7 @@ gcode:
   {% if tl.takingframe %}
     UPDATE_DELAYED_GCODE ID=_WAIT_TIMELAPSE_TAKE_FRAME DURATION={tl.check_time}
   {% else %}
+    G0 X{tl.restore.pos.x} Y{tl.restore.pos.y} Z{tl.restore.pos.z}
     {tl.macro.resume} VELOCITY={tl.speed.travel} ; execute the klipper RESUME command
     SET_GCODE_VARIABLE MACRO=TIMELAPSE_TAKE_FRAME VARIABLE=is_paused VALUE=False
     {% if not printer[printer.toolhead.extruder].can_extrude %}


### PR DESCRIPTION
When resuming the print the toolhead had a chance of wiping plastic on the outside of the model as it returned.  This patch adds a move back to a point above where it started before resuming.  With a suitable "dz" this elminiated branching (like stringing) for me.

Signed off by: Paul Bone <paul@bone.id.au>