### PR TITLE
timelapse: add configurable wget timeout for slow cameras

### DIFF
--- a/component/timelapse.py
+++ b/component/timelapse.py
@@ -64,6 +64,8 @@ class Timelapse:
             "ffmpeg_binary_path", "/usr/bin/ffmpeg")
         self.wget_skip_cert = confighelper.getboolean(
             "wget_skip_cert_check", False)
+        self.wget_timeout = confighelper.getfloat(
+            "wget_timeout", 2.0)
 
         # Setup default config
         self.config: Dict[str, Any] = {
@@ -478,7 +480,7 @@ class Timelapse:
         shell_cmd: SCMDComp = self.server.lookup_component('shell_command')
         scmd = shell_cmd.build_shell_command(cmd, None)
         try:
-            cmdstatus = await scmd.run(timeout=2., verbose=False)
+            cmdstatus = await scmd.run(timeout=self.wget_timeout, verbose=False)
         except Exception:
             logging.exception(f"Error running cmd '{cmd}'")
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -145,6 +145,11 @@ add additional idle time when parking (Unit seconds, default 0.1)
 #### stream_delay_compensation
 delay frame capture (Unit seconds, default 0.05)
 
+#### wget_timeout
+Defines the timeout for the wget command when downloading frames from the camera.
+This is useful when using high-resolution cameras or slow network connections that
+may take longer than the default 2 seconds to download a frame.
+
 ### Render specific
 
 #### time_format_code
@@ -240,6 +245,7 @@ does.
 #previewimage: True
 #saveframes: False
 #wget_skip_cert_check: False
+#wget_timeout: 5.0
 
 ```
 


### PR DESCRIPTION
## Description
Fixes #173 "Error taking timelapse frame" issue for slow cameras and network connections.

## Problem
The current hardcoded 2-second wget timeout is insufficient for:
- High-resolution (4K) cameras that generate 3-4MB images
- Unstable Wi-Fi connections
- IP camera apps with variable response times

Users report download times up to 2.3 seconds, causing frequent timeouts.

## Solution
- Add configurable `wget_timeout` option in moonraker.conf
- Default: 2.0 seconds (backward compatible)
- Fully documented in configuration.md

## Testing
- [x] Code passes pycodestyle validation
- [x] Backward compatibility maintained
- [x] Documentation updated

## Configuration Example
```ini
[timelapse]
wget_timeout: 5.0  # For 4K cameras or slow connections
```