### PR TITLE
Fix grammar in timelapse configuration comments

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -253,7 +253,7 @@ To do so, please refer to the documentation of your Image:
 
 ## Reduce the check interval inside the klipper macros
 The default is that the macros check every 0.5 sec if the print can continue.
-This is a good compromise between cpu load and quality. From now one you can change
+This is a good compromise between cpu load and quality. You can now change
 this time.
 Caution, smaller numbers increase the risk of a klipper "timer to close"
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -43,8 +43,8 @@ Advanced Settings -> Gcode -> Layer Change Gcode -> ``TIMELAPSE_TAKE_FRAME``
 [timelapse]
 ##   Following basic configuration is default to most images and don't need
 ##   to be changed in most scenarios. Only uncomment and change it if your
-##   Image differ from standart installations. In most common scenarios 
-##   a User only need [timelapse] in their configuration.
+##   Image differ from standard installations. In most common scenarios 
+##   a User only needs [timelapse] in their configuration.
 #output_path: ~/timelapse/
 ##   Directory where the generated video will be saved
 #frame_path: /tmp/timelapse/

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -43,8 +43,8 @@ Advanced Settings -> Gcode -> Layer Change Gcode -> ``TIMELAPSE_TAKE_FRAME``
 [timelapse]
 ##   Following basic configuration is default to most images and don't need
 ##   to be changed in most scenarios. Only uncomment and change it if your
-##   Image differ from standard installations. In most common scenarios 
-##   a User only needs [timelapse] in their configuration.
+##   Images may differ from standard installations. In most common scenarios,
+##   a user only needs [timelapse] in their configuration.
 #output_path: ~/timelapse/
 ##   Directory where the generated video will be saved
 #frame_path: /tmp/timelapse/


### PR DESCRIPTION
Correct small typographical errors in configuration notes.