### PR TITLE
fix: resume frame numbering after a Moonraker restart mid-print

### DIFF
--- a/component/timelapse.py
+++ b/component/timelapse.py
@@ -169,6 +169,23 @@ class Timelapse:
 
     async def component_init(self) -> None:
         await self.getWebcamConfig()
+        self.seed_framecount()
+
+    def seed_framecount(self) -> None:
+        # Resume numbering from what is already on disk. Without this a
+        # moonraker restart mid print resets the counter back to 0 and every
+        # frame captured so far gets overwritten, silently: the survivors are
+        # numbered contiguously from 1, so the rendered video simply starts
+        # part way through the print.
+        highest = 0
+        for filepath in glob.glob(self.temp_dir + "frame*.jpg"):
+            match = re.match(r"frame(\d+)\.jpg$", os.path.basename(filepath))
+            if match:
+                highest = max(highest, int(match.group(1)))
+
+        if highest:
+            logging.info(f"resuming timelapse frame numbering at {highest}")
+        self.framecount = highest
 
     def overwriteDbconfigWithConfighelper(self) -> None:
         blockedsettings = []


### PR DESCRIPTION
A moonraker restart while a print is running silently destroys the timelapse
captured so far. `framecount` lives only in memory and is never reconciled
against the frame directory, so it returns to 0 on restart, the next
`TIMELAPSE_TAKE_FRAME` writes `frame000001.jpg` over the original, and numbering
runs up from 1 again, overwriting in place. Nothing errors, and because the
survivors end up contiguously numbered from 1 the rendered video looks complete
— it just begins part way through the print.

Caught on an 8h52m print in `layermacro` mode where moonraker restarted roughly
half way through. From `moonraker.log`:

```
2026-07-27 08:21:29,480  wget … -O …/frames/frame000001.jpg   ← first pass
2026-07-27 12:30:33,158  wget … -O …/frames/frame000001.jpg   ← after the restart
2026-07-27 08:27:13,475  wget … -O …/frames/frame000002.jpg
2026-07-27 12:31:41,020  wget … -O …/frames/frame000002.jpg
```

541 snapshots were fetched over that print but only 281 distinct frame numbers
were ever written, so 260 frames were destroyed and the first 4h08m of the
resulting video was simply gone. Both capture modes are affected — `hyperlapse`
and `layermacro` both funnel through `newframe()` — and it reproduced
independently on a second machine running `hyperlapse`.

The fix seeds the counter at component init from the highest frame index already
on disk. Max index rather than file count, so it stays correct if a frame is ever
missing; the count form would collide with an existing file. A genuinely new
print is unaffected: `"File selected"` calls `cleanup()`, which empties the
directory and zeroes the counter before any frame is taken, and in `hyperlapse`
mode `start_hyperlapse` is spawned from that same handler. The seeded value can
therefore only be observed between component init and the next print start, and
nothing writes frames in that window.

## Test plan

- [x] `pycodestyle --ignore=E226,E301,E302,E303,W503,W504 --max-line-length=80
      --max-doc-length=80 component/` clean — the repo has no test suite, so
      this plus the manual pass below is the whole check
- [x] `seed_framecount` exercised offline against fixture directories: empty dir
      → 0, contiguous 1..132 → 132, gap `{1,3}` → 3, non-frame files ignored
- [ ] Manual test pass (see checklist below)

## Manual test pass

- [x] Restart moonraker with 3 planted frames in the frame directory (K1C 2025);
      `GET /machine/timelapse/lastframeinfo` reports `framecount: 3`, was `0`
- [x] Restart moonraker with 132 real frames left from an earlier print (K1C);
      `lastframeinfo` reports `framecount: 132`, was `0`
- [ ] Restart moonraker mid print and confirm the next frame captured is `N+1`
      rather than `frame000001.jpg`, and that the rendered video covers the
      whole print

Two caveats on those field results, stated plainly. What is deployed on the two
printers is the one-line `len(glob(...))` variant rather than the max-index form
in this diff; both frame directories were contiguous so the two forms agree
there, but the exact code here has only been exercised by the offline fixture
tests, not on hardware. And the end-to-end case — the last unchecked box — has
not been run at all; only the init-time seed was measured.
